### PR TITLE
docs(readme): clarify pip install limitations and recommend uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,19 @@ This tool currently supports exporting the following Feishu/Lark document compon
 
 ### CLI
 
-`export-browser` requires Playwright:
+`export-browser` requires Playwright.
+
+If you installed via `uv tool install`, add Playwright as an extra dependency:
 
 ```bash
-uv pip install playwright  # or: pip install playwright
+uv tool install --with playwright feishu-docx
+playwright install chromium
+```
+
+If you are working inside a virtual environment:
+
+```bash
+pip install playwright
 playwright install chromium
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,16 +40,39 @@
 - ☁️ **Cloud-Space Management** — List files, delete files, manage permissions, clear files safely
 - 🔐 **Authentication** — One-time auth, automatic token refresh
 - 🎨 **Dual Interface** — CLI + Beautiful TUI (Textual-based)
-- 📦 **Zero Config** — `pip install` and start exporting
+- 📦 **Easy Install** — `uv tool install feishu-docx` or `pip install feishu-docx`
 
 ---
 
 ## ⚡ Quick Start (30 seconds)
 
-```bash
-# Install
-pip install feishu-docx
+### Install
 
+**Recommended: `uv tool install`** (isolated, no conflicts with system Python)
+
+```bash
+uv tool install feishu-docx
+```
+
+Or run directly without installing:
+
+```bash
+uvx feishu-docx export "https://my.feishu.cn/wiki/xxx"
+```
+
+If you don't have `uv` yet: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+
+**Alternative: `pip install`** (works inside a virtual environment or with `--break-system-packages`)
+
+```bash
+pip install feishu-docx
+```
+
+> ⚠️ `pip install` outside a virtual environment may fail with `externally-managed-environment` on modern Linux/macOS (PEP 668). Use a virtual environment or `uv tool install` instead.
+
+### Configure and Export
+
+```bash
 # Configure credentials (one-time)
 feishu-docx config set --app-id YOUR_APP_ID --app-secret YOUR_APP_SECRET
 
@@ -136,7 +159,7 @@ This tool currently supports exporting the following Feishu/Lark document compon
 `export-browser` requires Playwright:
 
 ```bash
-pip install playwright
+uv pip install playwright  # or: pip install playwright
 playwright install chromium
 ```
 


### PR DESCRIPTION
## Problem

`pip install feishu-docx` fails with `externally-managed-environment` on modern Linux distributions (Ubuntu 23.04+, Debian 12+, etc.) and macOS with Homebrew Python. This is due to PEP 668, which prevents `pip install` from modifying the system Python outside a virtual environment.

Users who follow the current Quick Start instructions hit this error immediately, creating a poor first experience.

## Solution

- **Recommend `uv tool install feishu-docx`** as the primary install method — it creates an isolated environment automatically, works everywhere, and never conflicts with system Python
- **Add `uvx feishu-docx`** as a one-shot execution option (no install needed)
- **Keep `pip install feishu-docx`** as an alternative with a clear explanation of when it works (inside a venv) and when it doesn't
- Add a note explaining the `externally-managed-environment` error and what PEP 668 means for users
- Update the Playwright install example to also show `uv pip install`

## Changes

- Quick Start section: restructured to show uv as recommended, pip as alternative
- Added warning about `externally-managed-environment` / PEP 668
- Added `uvx` one-shot usage example
- Added uv install link for users who don't have it yet
- Updated `export-browser` Playwright install example